### PR TITLE
Add platform dependent modules to optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
   "dependencies": {
     "platform-dependent-modules": "0.0.14"
   },
+  "optionalDependencies": {
+    "exiftool.exe": "10.33",
+    "exiftool.pl": "10.33"
+  },
   "config": {
     "platformDependentModules": {
       "linux": [


### PR DESCRIPTION
Without this, I was unable to run `npm ls` in a project including `dist-exiftool` without it erroring with some response like

```
npm ERR! invalid: exiftool.pl@10.33.0 /projects/project/node_modules/dist-exiftool/node_modules/exiftool.pl
```